### PR TITLE
Consume api

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -4,4 +4,8 @@ class Api::V1::ItemsController < ApplicationController
     render json: Item.all
   end
 
+  def show
+    render json: Item.find(params[:id])
+  end
+
 end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::ItemsController < ApplicationController
+
+  def index
+    render json: Item.all
+  end
+
+end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -13,4 +13,14 @@ class Api::V1::ItemsController < ApplicationController
     render json: { head: :no_content }
   end
 
+  def create
+    render json: Item.create(item_params)
+  end
+
+  private
+
+    def item_params
+      params.require(:item).permit(:name, :description, :image_url)
+    end
+
 end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -8,4 +8,9 @@ class Api::V1::ItemsController < ApplicationController
     render json: Item.find(params[:id])
   end
 
+  def destroy
+    Item.delete(params[:id])
+    render json: { head: :no_content }
+  end
+
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,0 +1,7 @@
+class SearchController < ApplicationController
+
+  def index
+
+  end
+
+end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,7 +1,7 @@
 class SearchController < ApplicationController
 
   def index
-
+    @stores = Store.find_nearby_stores(params[:search_box])
   end
 
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -1,7 +1,27 @@
 class Store
 
+  attr_reader :total, :name, :city, :distance, :phone, :type
+
+  def initialize(attrs={})
+    @name = attrs[:longName]
+    @city = attrs[:city]
+    @distance = attrs[:ditance]
+    @phone = attrs[:phone]
+    @type = attrs[:storeType]
+  end
+
   def self.find_nearby_stores(zip)
-    raw_stores = BestBuyService.find_nearby_stores(zip)
+    @raw_stores = BestBuyService.find_nearby_stores(zip)
+    parse_stores(@raw_stores)
+  end
+
+  def self.parse_stores(stores)
+    store_instances = stores[:stores]
+    store_instances.map { |store| Store.new(store) }
+  end
+
+  def self.total
+    @raw_stores[:total]
   end
 
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -1,7 +1,7 @@
 class Store
 
   def self.find_nearby_stores(zip)
-    BestBuyService.find_nearby_stores(zip)
+    raw_stores = BestBuyService.find_nearby_stores(zip)
   end
 
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -1,0 +1,7 @@
+class Store
+
+  def self.find_nearby_stores(zip)
+    BestBuyService.find_nearby_stores(zip)
+  end
+
+end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -1,11 +1,11 @@
 class Store
 
-  attr_reader :total, :name, :city, :distance, :phone, :type
+  attr_reader :name, :city, :distance, :phone, :type, :total
 
   def initialize(attrs={})
     @name = attrs[:longName]
     @city = attrs[:city]
-    @distance = attrs[:ditance]
+    @distance = attrs[:distance]
     @phone = attrs[:phone]
     @type = attrs[:storeType]
   end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,3 @@
+class ItemSerializer < ActiveModel::Serializer
+  attributes :id, :name, :description, :image_url
+end

--- a/app/services/best_buy_service.rb
+++ b/app/services/best_buy_service.rb
@@ -1,0 +1,7 @@
+class BestBuyService
+
+  def self.find_nearby_stores(zip)
+    
+  end
+
+end

--- a/app/services/best_buy_service.rb
+++ b/app/services/best_buy_service.rb
@@ -1,7 +1,24 @@
 class BestBuyService
 
-  def self.find_nearby_stores(zip)
-    
+  def initialize(zip)
+    @_conn = Faraday.new("https://api.bestbuy.com")
+    @zip = zip
   end
+
+  def self.find_nearby_stores(zip)
+    service = BestBuyService.new(zip)
+    service.find_nearby_stores
+  end
+
+  def find_nearby_stores
+    response = conn.get("/v1/stores(area(#{@zip},25))?format=json&show=longName,city,distance,phone,storeType&apiKey=#{ENV['BEST_BUY_KEY']}")
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  private
+
+    def conn
+      @_conn
+    end
 
 end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -20,7 +20,7 @@
         <a href="/orders">Orders</a>
       </li>
       <%= form_tag(search_path, method: 'get', class: 'navbar-form navbar-right') do %>
-        <%= search_field_tag 'search-box', nil, class: 'form-control', placeholder: 'Search'  %>
+        <%= search_field_tag 'search_box', nil, class: 'form-control', placeholder: 'Search'  %>
         <%= submit_tag "search", class: 'btn btn-default', :name => nil %>
       <% end %>
     </ul>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -19,6 +19,10 @@
       <li>
         <a href="/orders">Orders</a>
       </li>
+      <%= form_tag(search_path, method: 'get', class: 'navbar-form navbar-right') do %>
+        <%= search_field_tag 'search-box', nil, class: 'form-control', placeholder: 'Search'  %>
+        <%= submit_tag "search", class: 'btn btn-default', :name => nil %>
+      <% end %>
     </ul>
   </div>
 </nav>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,13 +1,13 @@
 <h1>Search Results</h1>
 
-<h3><%= Store.total %> Total Stores</h3>
+<h3><%= Store.total %> Total Stores</h3><br/>
 
 <ul>
   <% @stores.each do |store| %></li>
-    <li><%= store.name %></li>
-    <li><%= store.city %></li>
-    <li><%= store.distance %></li>
-    <li><%= store.phone %></li>
-    <li><%= store.type %></li>
+    <h5><%= store.name %></h5>
+    <li><strong>City: </strong><%= store.city %></li>
+    <li><strong>Distance: </strong><%= store.distance %></li>
+    <li><strong>Phone: </strong><%= store.phone %></li>
+    <li><strong>Store-type: </strong><%= store.type %></li><br/>
   <% end %>
 </ul>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,0 +1,13 @@
+<h1>Search Results</h1>
+
+<h3><%= @stores.total %> Total Stores</h3>
+
+<ul>
+  <% @stores.each do |store| %></li>
+    <li><%= store.name %></li>
+    <li><%= store.city %></li>
+    <li><%= store.distance %></li>
+    <li><%= store.phone %></li>
+    <li><%= store.type %></li>
+  <% end %>
+</ul>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Search Results</h1>
 
-<h3><%= @stores.total %> Total Stores</h3>
+<h3><%= Store.total %> Total Stores</h3>
 
 <ul>
   <% @stores.each do |store| %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :items, only: [:index]
+      resources :items, only: [:index, :show]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :items, only: [:index, :show, :destroy]
+      resources :items, only: [:index, :show, :destroy, :create]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,10 @@ Rails.application.routes.draw do
   resources :users,  only: [:index, :show]
 
   get '/search', to: "search#index"
+
+  namespace :api do
+    namespace :v1 do
+      resources :items, only: [:index]
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,6 @@ Rails.application.routes.draw do
   resources :items,  only: [:index, :show]
   resources :orders, only: [:index, :show]
   resources :users,  only: [:index, :show]
+
+  get '/search', to: "search#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :items, only: [:index, :show]
+      resources :items, only: [:index, :show, :destroy]
     end
   end
 end

--- a/spec/features/user_can_search_for_stores_spec.rb
+++ b/spec/features/user_can_search_for_stores_spec.rb
@@ -11,7 +11,6 @@ require 'rails_helper'
 
 RSpec.feature "As a user" do
   scenario "they can search for nearby stores using their zipcode" do
-    skip
     VCR.use_cassette("search_by_zip") do
 
       visit '/'

--- a/spec/features/user_can_search_for_stores_spec.rb
+++ b/spec/features/user_can_search_for_stores_spec.rb
@@ -22,9 +22,17 @@ RSpec.feature "As a user" do
       expect(current_path).to eq('/search')
       expect(page).to have_content("16 Total Stores")
 
-      expect(page).to have_content("FIRST STORE DATA")
-      expect(page).to have_content("LAST STORE DATA")
+      expect(page).to have_content("BEST BUY MOBILE - CHERRY CREEK SHOPPING CENTER")
+      expect(page).to have_content("DENVER")
+      expect(page).to have_content("3.45")
+      expect(page).to have_content("303-270-9189")
+      expect(page).to have_content("Mobile SAS")
 
+      expect(page).to have_content("BEST BUY - SOUTHGLENN")
+      expect(page).to have_content("CENTENNIAL")
+      expect(page).to have_content("11.02")
+      expect(page).to have_content("303-797-3246")
+      expect(page).to have_content("Big Box")
     end
   end
 end

--- a/spec/features/user_can_search_for_stores_spec.rb
+++ b/spec/features/user_can_search_for_stores_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "As a user" do
 
       visit '/'
 
-      fill_in "search-box", with: "80202"
+      fill_in "search_box", with: "80202"
 
       click_on "search"
 

--- a/spec/features/user_can_search_for_stores_spec.rb
+++ b/spec/features/user_can_search_for_stores_spec.rb
@@ -21,7 +21,9 @@ RSpec.feature "As a user" do
 
       expect(current_path).to eq('/search')
       expect(page).to have_content("16 Total Stores")
-      
+
+      expect(page).to have_content("FIRST STORE DATA")
+      expect(page).to have_content("LAST STORE DATA")
 
     end
   end

--- a/spec/features/user_can_search_for_stores_spec.rb
+++ b/spec/features/user_can_search_for_stores_spec.rb
@@ -11,6 +11,7 @@ require 'rails_helper'
 
 RSpec.feature "As a user" do
   scenario "they can search for nearby stores using their zipcode" do
+    skip
     VCR.use_cassette("search_by_zip") do
 
       visit '/'

--- a/spec/features/user_can_search_for_stores_spec.rb
+++ b/spec/features/user_can_search_for_stores_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+# As a user
+# When I visit "/"
+# And I fill in a search box with "80202" and click "search"
+# Then my current path should be "/search" (ignoring params)
+# And I should see stores within 25 miles of 80202
+# And I should see a message that says "16 Total Stores"
+# And I should see exactly 10 results
+# And I should see the long name, city, distance, phone number and store type for each of the 10 results
+
+RSpec.feature "As a user" do
+  scenario "they can search for nearby stores using their zipcode" do
+    VCR.use_cassette("search_by_zip") do
+
+      visit '/'
+
+      fill_in "search-box", with: "80202"
+
+      click_on "search"
+
+      expect(current_path).to eq('/search')
+      expect(page).to have_content("16 Total Stores")
+      
+
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/_find_nearby_stores_zip_.yml
+++ b/spec/fixtures/vcr_cassettes/_find_nearby_stores_zip_.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.bestbuy.com/v1/stores(area(80202,25))?apiKey=<BEST_BUY_KEY>&format=json&show=longName,city,distance,phone,storeType
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.11.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, x-requested-with, accept
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '3628800'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 01 Jun 2017 16:25:19 GMT
+      Server:
+      - Best Buy Public APIs
+      X-Cache-Hit:
+      - 'false'
+      Content-Length:
+      - '1520'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"from":1,"to":10,"currentPage":1,"total":16,"totalPages":2,"queryTime":"0.032","totalTime":"0.046","partial":false,"canonicalUrl":"/v1/stores(area(\"80202\",25))?show=longName,city,distance,phone,storeType&format=json&apiKey=<BEST_BUY_KEY>","stores":[{"longName":"BEST
+        BUY MOBILE - CHERRY CREEK SHOPPING CENTER","city":"DENVER","distance":3.45,"phone":"303-270-9189","storeType":"Mobile
+        SAS"},{"longName":"BEST BUY - BELMAR","city":"LAKEWOOD","distance":5.31,"phone":"303-742-8039","storeType":"Big
+        Box"},{"longName":"BEST BUY - COLORADO BLVD","city":"DENVER","distance":5.59,"phone":"303-758-5805","storeType":"Big
+        Box"},{"longName":"BEST BUY - DENVER WEST","city":"LAKEWOOD","distance":8.39,"phone":"303-273-5617","storeType":"Big
+        Box"},{"longName":"BEST BUY - WESTMINSTER","city":"WESTMINSTER","distance":8.52,"phone":"303-426-4434","storeType":"Big
+        Box"},{"longName":"BEST BUY - NORTHGLENN","city":"DENVER","distance":9.14,"phone":"303-252-8677","storeType":"Big
+        Box"},{"longName":"BEST BUY MOBILE - TOWN CENTER AT AURORA","city":"AURORA","distance":9.73,"phone":"303-326-0848","storeType":"Mobile
+        SAS"},{"longName":"BEST BUY - AURORA","city":"AURORA","distance":9.79,"phone":"303-338-5797","storeType":"Big
+        Box"},{"longName":"BEST BUY - LITTLETON","city":"LAKEWOOD","distance":10.44,"phone":"303-932-7830","storeType":"Big
+        Box"},{"longName":"BEST BUY - SOUTHGLENN","city":"CENTENNIAL","distance":11.02,"phone":"303-797-3246","storeType":"Big
+        Box"}],"warnings":"Distances are in terms of miles (default)"}'
+    http_version: 
+  recorded_at: Thu, 01 Jun 2017 16:24:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/search_by_zip.yml
+++ b/spec/fixtures/vcr_cassettes/search_by_zip.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.bestbuy.com/v1/stores(area(80202,25))?apiKey=<BEST_BUY_KEY>&format=json&show=longName,city,distance,phone,storeType
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.11.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, x-requested-with, accept
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '3628800'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 01 Jun 2017 16:59:53 GMT
+      Server:
+      - Best Buy Public APIs
+      X-Cache-Hit:
+      - 'true'
+      Content-Length:
+      - '1520'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"from":1,"to":10,"currentPage":1,"total":16,"totalPages":2,"queryTime":"0.032","totalTime":"0.046","partial":false,"canonicalUrl":"/v1/stores(area(\"80202\",25))?show=longName,city,distance,phone,storeType&format=json&apiKey=<BEST_BUY_KEY>","stores":[{"longName":"BEST
+        BUY MOBILE - CHERRY CREEK SHOPPING CENTER","city":"DENVER","distance":3.45,"phone":"303-270-9189","storeType":"Mobile
+        SAS"},{"longName":"BEST BUY - BELMAR","city":"LAKEWOOD","distance":5.31,"phone":"303-742-8039","storeType":"Big
+        Box"},{"longName":"BEST BUY - COLORADO BLVD","city":"DENVER","distance":5.59,"phone":"303-758-5805","storeType":"Big
+        Box"},{"longName":"BEST BUY - DENVER WEST","city":"LAKEWOOD","distance":8.39,"phone":"303-273-5617","storeType":"Big
+        Box"},{"longName":"BEST BUY - WESTMINSTER","city":"WESTMINSTER","distance":8.52,"phone":"303-426-4434","storeType":"Big
+        Box"},{"longName":"BEST BUY - NORTHGLENN","city":"DENVER","distance":9.14,"phone":"303-252-8677","storeType":"Big
+        Box"},{"longName":"BEST BUY MOBILE - TOWN CENTER AT AURORA","city":"AURORA","distance":9.73,"phone":"303-326-0848","storeType":"Mobile
+        SAS"},{"longName":"BEST BUY - AURORA","city":"AURORA","distance":9.79,"phone":"303-338-5797","storeType":"Big
+        Box"},{"longName":"BEST BUY - LITTLETON","city":"LAKEWOOD","distance":10.44,"phone":"303-932-7830","storeType":"Big
+        Box"},{"longName":"BEST BUY - SOUTHGLENN","city":"CENTENNIAL","distance":11.02,"phone":"303-797-3246","storeType":"Big
+        Box"}],"warnings":"Distances are in terms of miles (default)"}'
+    http_version: 
+  recorded_at: Thu, 01 Jun 2017 16:58:56 GMT
+recorded_with: VCR 3.0.3

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe "Store" do
+  it ".find_nearby_stores(zip)" do
+    VCR.use_cassette(".find_nearby_stores(zip)") do
+
+      zip = "80202"
+
+      stores = Store.find_nearby_stores(zip)
+
+      expect(stores).to be_an(Array)
+      expect(stores.count).to eq(10)
+      expect(stores.total).to eq(16)
+
+      expect(store.first.name).to eq("BEST BUY MOBILE - CHERRY CREEK SHOPPING CENTER")
+      expect(store.first.city).to eq("DENVER")
+      expect(store.first.distance).to eq("3.45")
+      expect(store.first.phone).to eq("303-270-9189")
+      expect(store.first.type).to eq("Mobile SAS")
+
+      expect(store.last.name).to eq("BEST BUY - SOUTHGLENN")
+      expect(store.last.city).to eq("CENTENNIAL")
+      expect(store.last.distance).to eq("11.02")
+      expect(store.last.phone).to eq("303-797-3246")
+      expect(store.lat.type).to eq("Big Box")
+    end
+  end
+end

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -14,15 +14,15 @@ RSpec.describe "Store" do
 
       expect(stores.first.name).to eq("BEST BUY MOBILE - CHERRY CREEK SHOPPING CENTER")
       expect(stores.first.city).to eq("DENVER")
-      expect(stores.first.distance).to eq("3.45")
+      expect(stores.first.distance).to eq(3.45)
       expect(stores.first.phone).to eq("303-270-9189")
       expect(stores.first.type).to eq("Mobile SAS")
 
       expect(stores.last.name).to eq("BEST BUY - SOUTHGLENN")
       expect(stores.last.city).to eq("CENTENNIAL")
-      expect(stores.last.distance).to eq("11.02")
+      expect(stores.last.distance).to eq(11.02)
       expect(stores.last.phone).to eq("303-797-3246")
-      expect(stores.lat.type).to eq("Big Box")
+      expect(stores.last.type).to eq("Big Box")
     end
   end
 end

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -10,19 +10,19 @@ RSpec.describe "Store" do
 
       expect(stores).to be_an(Array)
       expect(stores.count).to eq(10)
-      expect(stores.total).to eq(16)
+      expect(Store.total).to eq(16)
 
-      expect(store.first.name).to eq("BEST BUY MOBILE - CHERRY CREEK SHOPPING CENTER")
-      expect(store.first.city).to eq("DENVER")
-      expect(store.first.distance).to eq("3.45")
-      expect(store.first.phone).to eq("303-270-9189")
-      expect(store.first.type).to eq("Mobile SAS")
+      expect(stores.first.name).to eq("BEST BUY MOBILE - CHERRY CREEK SHOPPING CENTER")
+      expect(stores.first.city).to eq("DENVER")
+      expect(stores.first.distance).to eq("3.45")
+      expect(stores.first.phone).to eq("303-270-9189")
+      expect(stores.first.type).to eq("Mobile SAS")
 
-      expect(store.last.name).to eq("BEST BUY - SOUTHGLENN")
-      expect(store.last.city).to eq("CENTENNIAL")
-      expect(store.last.distance).to eq("11.02")
-      expect(store.last.phone).to eq("303-797-3246")
-      expect(store.lat.type).to eq("Big Box")
+      expect(stores.last.name).to eq("BEST BUY - SOUTHGLENN")
+      expect(stores.last.city).to eq("CENTENNIAL")
+      expect(stores.last.distance).to eq("11.02")
+      expect(stores.last.phone).to eq("303-797-3246")
+      expect(stores.lat.type).to eq("Big Box")
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,7 +14,7 @@ require 'support/factory_girl'
 VCR.configure do |config|
   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
   config.hook_into :webmock
-  config.filter_sensitive_data('<WEATHER_UNDERGROUND_KEY>') { ENV['WEATHER_UNDERGROUND_KEY'] }
+  config.filter_sensitive_data('<BEST_BUY_KEY>') { ENV['BEST_BUY_KEY'] }
 end
 
 DatabaseCleaner.strategy = :truncation

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe "Item API" do
+  it "Displays all items" do
+    create_list(:item, 3)
+
+    get "/api/v1/items"
+
+    expect(response).to be_success
+    expect(Item.count).to eq(3)
+  end
+end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -37,4 +37,24 @@ RSpec.describe "Item API" do
     expect(response).to be_success
     expect(Item.count).to eq(0)
   end
+
+  it "Creates an item" do
+    item = create(:item)
+    id = item.id
+    name = item.name
+
+    expect(Item.count).to eq(1)
+
+    item_params = { name: "Computer", description: "Good computer.", image_url: "url" }
+
+    post "/api/v1/items", { item: item_params }
+
+    new_item = Item.last
+
+    expect(response).to be_success
+    expect(Item.count).to eq(2)
+    expect(new_item.name).to eq("Computer")
+    expect(new_item.description).to eq("Good computer.")
+    expect(new_item.image_url).to eq("url")
+  end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -24,4 +24,17 @@ RSpec.describe "Item API" do
 
     expect(item["id"]).to eq(id)
   end
+
+  it "Deletes an item" do
+    item = create(:item)
+    id = item.id
+    name = item.name
+
+    expect(Item.count).to eq(1)
+
+    delete "/api/v1/items/#{id}"
+
+    expect(response).to be_success
+    expect(Item.count).to eq(0)
+  end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -6,7 +6,22 @@ RSpec.describe "Item API" do
 
     get "/api/v1/items"
 
+    items = JSON.parse(response.body)
+
     expect(response).to be_success
-    expect(Item.count).to eq(3)
+    expect(items.count).to eq(3)
+  end
+
+  it "Displays a single item" do
+    item = create(:item)
+    id = item.id
+
+    get "/api/v1/items/#{id}"
+
+    expect(response).to be_success
+
+    item = JSON.parse(response.body)
+
+    expect(item["id"]).to eq(id)
   end
 end

--- a/spec/services/best_buy_service_spec.rb
+++ b/spec/services/best_buy_service_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "BestBuyService" do
+  it "finds the nearest stores and displays first 10 based on zipcode" do
+    VCR.use_cassette(".find_nearby_stores(zip)") do
+
+      zip = "80202"
+
+      raw_stores = BestBuyService.find_nearby_stores(zip)
+
+      expect(raw_stores).to be_a(Hash)
+      expect(raw_stores[:total]).to be_an(Integer)
+      expect(raw_stores[:stores]).to be_an(Array)
+      expect(raw_stores[:stores].count).to eq(10)
+      expect(raw_stores[:stores].first).to be_a(Hash)
+      expect(raw_stores[:stores].last).to be_a(Hash)
+    end
+  end
+end

--- a/spec/support/factories/items.rb
+++ b/spec/support/factories/items.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :item do
+    name { Faker::Hipster.word }
+    description { Faker::Hipster.sentence }
+    image_url { Faker::Internet.url }
+  end
+end


### PR DESCRIPTION
Adds functionality for consuming an API and building an internal API. The internal API at this point still shows the created_at and updated_at dates, which I tried to resolve using a serializer but ran out of time. I also ran out of time before I could test the internal endpoints in postman, although my RSpec tests are passing. I would assume that I need to create a separate controller that my API inherits from that has :null_session instead of :exception.